### PR TITLE
Redirect to new tutorial on using pretrained images.

### DIFF
--- a/data/exceptions.txt
+++ b/data/exceptions.txt
@@ -22,3 +22,4 @@ packages/r/index.html,api/r/index.html
 packages/r/mnistCompetition.html,api/r/mnistCompetition.html
 packages/r/ndarrayAndSymbolTutorial.html,api/r/ndarrayAndSymbolTutorial.html
 packages/scala/index.html,api/scala/index.html
+how_to/pretrained.html,tutorials/python/predict_imagenet.html

--- a/docs/how_to/pretrained.rst
+++ b/docs/how_to/pretrained.rst
@@ -1,2 +1,2 @@
 .. meta::
-    :http-equiv=refresh: 0;URL='http://mxnet.io/how_to/pretrained.html'
+    :http-equiv=refresh: 0;URL='http://mxnet.io/tutorials/python/predict_imagenet.html'


### PR DESCRIPTION
Fix 404 for some google results like "mxnet pre-trained model"